### PR TITLE
Update example: HAL section

### DIFF
--- a/rest-api-guidelines/message/hal.md
+++ b/rest-api-guidelines/message/hal.md
@@ -80,7 +80,7 @@ The `_embedded` field's object just contains the related resources HAL represent
     "self": { "href": "/orders" }
   },
   "_embedded": {
-    "order": [
+    "orders": [
       {
         "_links": {
           "self": { "href": "/orders/1" }


### PR DESCRIPTION
## Proposed Changes

Update example as described in the JSON Guidelines:

6. Array field names SHOULD be plural (e.g. `"orders": []`)

https://adidas.gitbook.io/api-guidelines/general-guidelines/json
