### PR TITLE
Pact

### DIFF
--- a/general-guidelines/contract.md
+++ b/general-guidelines/contract.md
@@ -2,5 +2,5 @@
 
 Approved API Design, represented by its API Description or schema, **MUST** represent the **contract** between API stakeholder, implementers, and consumers.
 
-Any change to an API **MUST** be accompanied by a related update to the contract \(API Design\).
+An update to the corresponding contract \(API Design\) **MUST** be implemented and approved before any change to an API **MUST**.
 

--- a/rest-api-guidelines/core-principles/testing.md
+++ b/rest-api-guidelines/core-principles/testing.md
@@ -1,6 +1,18 @@
 # Testing
 
+## DREED
+
 Every API description \(contract\) using HTTP\(S\) protocol **MUST** be tested against its API implementation. The tests **MUST** be executed using the [Dredd testing framework](https://github.com/apiaryio/dredd). The Dredd **MUST** [report the test results to Apiary](https://help.apiary.io/tools/automated-testing/testing-reporter/).
 
 In addition to local runs, the tests **SHOULD** be an integral part the API implementation's CI/CD pipeline. The CI/CD pipeline **SHOULD** be configured to run the test whenever there is a change to either API description \(contract\) or its implementation.
+
+## PACT
+
+Every adidas **CORE** API **MUST** be tested additionally applying Consumer Driven Contract Testing principles. The tests **MUST** be executed using the [PACT contract testing tool](https://docs.pact.io/). PACT tests **MUST** use adidas [PACT-Broker](http://pact.ati.adidas.com/) to store results and evidences.
+
+In addition to local runs, PACT tests **SHOULD** be an integral part of the API implementation's CI/CD pipeline. The CI/CD pipeline **SHOULD** be configured to run the test whenever there is a change to either API description \(contract\) or its implementation.
+
+Using Consumer Driven Contract Testing with PACT is *not mandatory* for adidas **NON-CORE** APIs, but strongly recommended due to the advantages this approach brings. It will be also a proof of our Software Engineering practices maturity.
+
+More information, guides and seeds about how to use PACT can be found on (internal link)[adidas Consumer Driven Contract Testing guide](https://tools.adidas-group.com/confluence/display/DSBP/adidas+Consumer+Driven+Contract+Testing+guide) page.
 

--- a/rest-api-guidelines/functionality/message/error-reporting.md
+++ b/rest-api-guidelines/functionality/message/error-reporting.md
@@ -122,5 +122,9 @@ A Problem Detail response **MUST NOT** contain a program stack trace or server l
 
 ## Working with Problem Detail
 
+An API description **SHOULD** list all the error codes with which the API responds. The error responses **SHOULD** describre the error object model schema. It is **RECOMMENDED** to include examples of a possible error response. The error description and/or error example **MAY** list all the types of errors returned for a given error code.
+
+## External resources
+
 There are a whole plethora of libraries working with Problem Detail, for example, see [Zalando / Problem](https://github.com/zalando/problem) \(Java\).
 

--- a/rest-api-guidelines/functionality/message/error-reporting.md
+++ b/rest-api-guidelines/functionality/message/error-reporting.md
@@ -124,7 +124,7 @@ A Problem Detail response **MUST NOT** contain a program stack trace or server l
 
 ## Working with Problem Detail
 
-An API description **SHOULD** list all the error codes with which the API responds. The error responses **SHOULD** describre the error object model schema. It is **RECOMMENDED** to include examples of a possible error response. The error description and/or error example **MAY** list all the types of errors returned for a given error code.
+An API description **CAN** list all the error codes with which the API responds. The error responses **SHOULD** describre the error object model schema. It is **RECOMMENDED** to include examples of a possible error response. The error description and/or error example **MAY** list all the types of errors returned for a given error code.
 
 ## External resources
 

--- a/rest-api-guidelines/functionality/message/error-reporting.md
+++ b/rest-api-guidelines/functionality/message/error-reporting.md
@@ -124,7 +124,7 @@ A Problem Detail response **MUST NOT** contain a program stack trace or server l
 
 ## Working with Problem Detail
 
-An API description **CAN** list all the error codes with which the API responds. The error responses **SHOULD** describre the error object model schema. It is **RECOMMENDED** to include examples of a possible error response. The error description and/or error example **MAY** list all the types of errors returned for a given error code.
+An API description **MAY** list all the error codes with which the API responds. The error responses **SHOULD** describre the error object model schema. It is **RECOMMENDED** to include examples of a possible error response. The error description and/or error example **MAY** list all the types of errors returned for a given error code.
 
 ## External resources
 

--- a/rest-api-guidelines/functionality/message/error-reporting.md
+++ b/rest-api-guidelines/functionality/message/error-reporting.md
@@ -4,7 +4,7 @@ The [`application/problem+json`](https://tools.ietf.org/html/rfc7807) \(Problem 
 
 Problem Detail is intended for use with the HTTP status codes 4xx and 5xx. Problem Detail **MUST NOT** be used with 2xx status code responses.
 
-At the minimum, any Problem Detail response **MUST** have the `title` and `detail` fields.
+At the minimum, any Problem Detail response **MUST** have the `title` and `detail` fields. `title` value **SHOULD NOT** change from occurrence to occurence of the problem, except for purposes of localization (e.g., using proactive content negotiation) [read more](https://tools.ietf.org/html/rfc7807#section-3.1)
 
 ### Example
 
@@ -14,6 +14,8 @@ At the minimum, any Problem Detail response **MUST** have the `title` and `detai
   "detail": "Missing authentication credentials for the Greeting resource."
 }
 ```
+
+> NOTE: `title` and `detail` fields **SHOULD NOT** be parsed to determine the nature of the error. Instead `type` **MUST** be used.
 
 ## Optional Fields
 
@@ -39,7 +41,7 @@ If needed, the Problem Detail **MAY** include additional fields, refer to [RFC78
 
 When necessary, a Problem Detail response **MAY** include additional error details about the problems that have occurred.
 
-These additional errors **MUST** be under the `errors` and **MUST** follow the Problem Detail structure.
+These additional errors **MUST** be under the `errors` collection and **MUST** follow the Problem Detail structure.
 
 ### Example
 
@@ -127,4 +129,3 @@ An API description **SHOULD** list all the error codes with which the API respon
 ## External resources
 
 There are a whole plethora of libraries working with Problem Detail, for example, see [Zalando / Problem](https://github.com/zalando/problem) \(Java\).
-


### PR DESCRIPTION
Fixes #
contract.md in order to not contradict the "design-first" rule

## Proposed Changes

  - Adding PACT mandatory for CORE APIs and recommended for the rest of them