### PR TITLE
Update Pagination example with naming conventions

### DIFF
--- a/rest-api-guidelines/execution/pagination.md
+++ b/rest-api-guidelines/execution/pagination.md
@@ -15,7 +15,7 @@ The Collection of Orders using the collection navigation link and `offset` and `
     "first": { "href": "/orders?limit=10" },
     "last": { "href": "/orders?offset=900&limit=10" }
   },
-  "total_count": 910,
+  "totalCount": 910,
   "_embedded": {
     "order": [
       { ... },


### PR DESCRIPTION
## Proposed Changes

  - Following the Naming Conventions, this example should show **totalCount** as camel case: https://adidas.gitbook.io/api-guidelines/rest-api-guidelines/evolution/naming-conventions#general-naming-rules
