### PR TITLE
fix(spectral): use kebab-case for paths

### DIFF
--- a/.spectral.yml
+++ b/.spectral.yml
@@ -10,7 +10,7 @@ rules:
   operation-2xx-response: error
 
   adidas-paths-kebab-case:
-    description: All YAML/JSON paths MUST follow kebab-case with template variables in camelCase
+    description: All YAML/JSON paths MUST follow kebab-case
     severity: warn
     recommended: true
     message: "{{property}} is not kebab-case: {{error}}"
@@ -18,7 +18,18 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: "^\/([a-z0-9]+(-[a-z0-9]+)*)?(\/[a-z0-9]+(-[a-z0-9]+)*|\/{[a-z][a-zA-Z0-9]+})*$" # doesn't allow /asasd{asdas}sadas pattern or not closed braces
+        match: "^\/([a-z0-9]+(-[a-z0-9]+)*)?(\/[a-z0-9]+(-[a-z0-9]+)*|\/{.+})*$" # doesn't allow /asasd{asdas}sadas pattern or not closed braces
+
+  adidas-path-parameters-camelCase-alphanumeric:
+    description: Path parameters MUST follow camelCase
+    severity: warn
+    recommended: true
+    message: "{{property}} path parameter is not camelCase: {{error}}"
+    given: $..parameters[?(@.in == 'path')].name
+    then:
+      function: pattern
+      functionOptions:
+        match: "^[a-z][a-zA-Z0-9]+$"
 
   adidas-definitions-camelCase-alphanumeric:
     description: All YAML/JSON definitions MUST follow fields-camelCase and be ASCII alphanumeric characters or `_` or `$`.

--- a/.spectral.yml
+++ b/.spectral.yml
@@ -9,17 +9,16 @@ rules:
   operation-tags: false
   operation-2xx-response: error
 
-  adidas-paths-camelCase:
-    description: All YAML/JSON paths MUST follow camelCase
+  adidas-paths-kebab-case:
+    description: All YAML/JSON paths MUST follow kebab-case with template variables in camelCase
     severity: warn
     recommended: true
-    message: "{{property}} is not camelCase: {{error}}"
+    message: "{{property}} is not kebab-case: {{error}}"
     given: $.paths[*]~
     then:
       function: pattern
       functionOptions:
-        # match: "/^(\/{1}(([{]?[a-z])[A-Za-z0-9]*[}]?)*)+$/" # - more generic one, allows /asasd{asdas}sadas pattern but also not closed braces
-        match: "^\/([a-z][a-zA-Z0-9]+)?(\/[a-z][a-zA-Z0-9]+|\/{[a-z][a-zA-Z0-9]+})*$" # doesn't allow /asasd{asdas}sadas pattern or not closed braces
+        match: "^\/([a-z0-9]+(-[a-z0-9]+)*)?(\/[a-z0-9]+(-[a-z0-9]+)*|\/{[a-z][a-zA-Z0-9]+})*$" # doesn't allow /asasd{asdas}sadas pattern or not closed braces
 
   adidas-definitions-camelCase-alphanumeric:
     description: All YAML/JSON definitions MUST follow fields-camelCase and be ASCII alphanumeric characters or `_` or `$`.
@@ -51,17 +50,6 @@ rules:
       function: pattern
       functionOptions:
         notMatch: "/^body$/"
-
-  adidas-uri-template-cannot-dash:
-    description: "The 'URI' template (RFC 6570 - https://tools.ietf.org/html/rfc6570) cannot contain a '-' character"
-    severity: error
-    recommended: true
-    message: "{{property}}: {{description}}"
-    given: "$.paths[*]~"
-    then:
-      function: pattern
-      functionOptions:
-        notMatch: "/-/"
 
   adidas-headers-no-x-headers:
     description: "All 'HTTP' headers SHOULD NOT include 'X-' headers (https://tools.ietf.org/html/rfc6648)."


### PR DESCRIPTION
## Proposed Changes

- Use kebab-case for paths
- Use camelCase for template variables

API guidelines [naming conventions](https://github.com/adidas/api-guidelines/blob/master/rest-api-guidelines/evolution/naming-conventions.md#uri) specify using kebab-case for paths:

> Every URI MUST follow the General Rules except for the camelCase rule. Instead, a hyphen (-) SHOULD be used to delimit combined words (kebab-case).

According to [RFC6570](https://tools.ietf.org/html/rfc6570) URI template format is the following:
> URI-Template  = *( literals / expression )

Literals allowed characters: `(reserved / unreserved / pct-encoded)`

Hyphen `-` is unreserved character:
> unreserved     =  ALPHA / DIGIT / "-" / "." / "_" / "~"

Note however, according to RFC hyphen is NOT allowed in URI template variable list:
> expression    =  "{" [ operator ] variable-list "}"
```
     variable-list =  varspec *( "," varspec )
     varspec       =  varname [ modifier-level4 ]
     varname       =  varchar *( ["."] varchar )
     varchar       =  ALPHA / DIGIT / "_" / pct-encoded
```

That's why I propose to use camelCase there as we use it in parameter definitions.